### PR TITLE
Cristian Eguia - Backend validation: prevent duplicate product names

### DIFF
--- a/api/Controllers/ProductController.cs
+++ b/api/Controllers/ProductController.cs
@@ -1,0 +1,111 @@
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using api.Models;
+using API.Data;
+
+namespace api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ProductController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ProductController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/product (Get all products)
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Product>>> GetProducts()
+        {
+            return await _context.Products.ToListAsync();
+        }
+
+        // GET: api/product/{id} (Get product by ID)
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Product>> GetProduct(int id)
+        {
+            var product = await _context.Products.FindAsync(id);
+            if (product == null)
+                return NotFound(new { message = "Product not found" });
+
+            return product;
+        }
+
+        // POST: api/product (Create a new product)
+        [HttpPost]
+        public async Task<ActionResult<Product>> CreateProduct([FromBody] Product product)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var existingProduct = await _context.Products
+                .FirstOrDefaultAsync(p => p.Name.ToLower() == product.Name.ToLower());
+
+            if (existingProduct != null)
+            {
+                return BadRequest(new { message = "A product with this name already exists." });
+            }
+
+            product.CreatedAt = DateTime.UtcNow;
+            product.UpdatedAt = DateTime.UtcNow;
+
+            _context.Products.Add(product);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction(nameof(GetProduct), new { id = product.Id }, product);
+        }
+
+        // PUT: api/product/{id} (Update an existing product)
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateProduct(int id, [FromBody] Product product)
+        {
+            if (id != product.Id)
+                return BadRequest(new { message = "Product ID mismatch" });
+
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var duplicateProduct = await _context.Products
+                .FirstOrDefaultAsync(p => p.Name.ToLower() == product.Name.ToLower() && p.Id != id);
+
+            if (duplicateProduct != null)
+            {
+                return BadRequest(new { message = "Another product with this name already exists." });
+            }
+
+            var existingProduct = await _context.Products.FindAsync(id);
+            if (existingProduct == null)
+                return NotFound(new { message = "Product not found" });
+
+            existingProduct.Name = product.Name;
+            existingProduct.Description = product.Description;
+            existingProduct.Price = product.Price;
+            existingProduct.StockQuantity = product.StockQuantity;
+            existingProduct.UpdatedAt = DateTime.UtcNow;
+
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+
+        // DELETE: api/product/{id} (Delete a product)
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteProduct(int id)
+        {
+            var product = await _context.Products.FindAsync(id);
+            if (product == null)
+                return NotFound(new { message = "Product not found" });
+
+            _context.Products.Remove(product);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/api/Data/ApplicationDbContext.cs
+++ b/api/Data/ApplicationDbContext.cs
@@ -1,3 +1,6 @@
+using Microsoft.EntityFrameworkCore;
+using api.Models;
+
 namespace API.Data
 {
     using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
@@ -6,9 +9,12 @@ namespace API.Data
     public class ApplicationDbContext : IdentityDbContext
     {
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
-        {
+        {         
+
 
         }
+
+        public DbSet<Product> Products { get; set; }
     }
 
 }

--- a/api/Data/ApplicationDbContext.cs
+++ b/api/Data/ApplicationDbContext.cs
@@ -11,7 +11,6 @@ namespace API.Data
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
         {         
 
-
         }
 
         public DbSet<Product> Products { get; set; }

--- a/api/Models/Product.cs
+++ b/api/Models/Product.cs
@@ -1,0 +1,34 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace api.Models
+{
+    public class Product
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required(ErrorMessage = "Product name is required.")]
+        [MaxLength(255, ErrorMessage = "Product name cannot exceed 255 characters.")]
+        public string Name { get; set; }
+
+        [MaxLength(1000, ErrorMessage = "Description cannot exceed 1000 characters.")]
+        public string? Description { get; set; }
+
+        [Required(ErrorMessage = "Price is required.")]
+        [Range(0.01, double.MaxValue, ErrorMessage = "Price must be greater than zero.")]
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal Price { get; set; }
+
+        [Required(ErrorMessage = "Stock quantity is required.")]
+        [Range(0, int.MaxValue, ErrorMessage = "Stock quantity cannot be negative.")]
+        public int StockQuantity { get; set; }
+
+        [Required]
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        [Required]
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    }
+}


### PR DESCRIPTION
This pull request adds validation to the backend controller to prevent duplicate product names.

Added in POST and PUT actions of `ProductController.cs`:
- Before saving a new product, checks if a product with the same name already exists (case-insensitive).
- In update, ensures another product doesn’t already use the target name.

This satisfies the assigned task:
**"Add validation to ensure product data is valid before saving to the database"**
