### PR TITLE
Add Product Filter by Category #96

### DIFF
--- a/api/Migrations/20250415123712_AddPendingChanges.Designer.cs
+++ b/api/Migrations/20250415123712_AddPendingChanges.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250415123712_AddPendingChanges")]
+    partial class AddPendingChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.3");

--- a/api/Migrations/20250415123712_AddPendingChanges.cs
+++ b/api/Migrations/20250415123712_AddPendingChanges.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPendingChanges : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Products",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Products");
+        }
+    }
+}

--- a/app/src/views/products/List.vue
+++ b/app/src/views/products/List.vue
@@ -1,3 +1,66 @@
 <template>
-    <h1>Welcome to the Product Listing Page.</h1>
+  <div>
+    <h2>Product Listing</h2>
+
+    <div>
+      <label for="category">Filter by Category:</label>
+      <select v-model="selectedCategoryId" @change="fetchProducts">
+        <option value="">All Categories</option>
+        <option
+          v-for="category in categories"
+          :key="category.id"
+          :value="category.id"
+        >
+          {{ category.name }}
+        </option>
+      </select>
+    </div>
+
+    <div v-if="products.length === 0">
+      <p>No products found.</p>
+    </div>
+    <ul v-else>
+      <li v-for="product in products" :key="product.id">
+        {{ product.name }} - ${{ product.price }}
+      </li>
+    </ul>
+  </div>
 </template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+
+const products = ref([])
+const categories = ref([])
+const selectedCategoryId = ref('')
+
+// Get categories when loading the view
+const fetchCategories = async () => {
+  try {
+    const res = await axios.get('/api/categories')
+    categories.value = res.data
+  } catch (error) {
+    console.error('Error fetching categories', error)
+  }
+}
+
+// Get filtered or unfiltered products
+const fetchProducts = async () => {
+  try {
+    const categoryParam = selectedCategoryId.value
+      ? `?categoryId=${selectedCategoryId.value}`
+      : ''
+    const res = await axios.get(`/api/products${categoryParam}`)
+    products.value = res.data
+  } catch (error) {
+    console.error('Error fetching products', error)
+  }
+}
+
+// On startup, load both
+onMounted(async () => {
+  await fetchCategories()
+  await fetchProducts()
+})
+</script>

--- a/product-management-system.sln
+++ b/product-management-system.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api", "api\api.csproj", "{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {40726670-8519-40A8-A1D7-ADF50B3737A3}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This pull request adds functionality to filter products by category in the basic product listing view.

- A dropdown menu was added to select the category.
- Categories are retrieved from the backend via `/api/categories`.
- Selecting a category retrieves filtered products from `/api/products?categoryId={id}`.
- Product names and prices are displayed in a basic list.

The implementation is straightforward as it fulfills task #96 and focuses on the filtering logic, as requested.